### PR TITLE
Filter unchanged corrections + content delimiter + line fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ The action runs from a Dockerfile that calls a shell script. This script has the
         - A string with the summary of the file review.
     3. Write the lists of issues in a JSON file (`issues.json`), which will be used for the next python script to post the suggestions.
     4. Aggregate the review summaries and use the GitHub API to post them as a single comment along with the feedback option.
-2. Verify if the `issues.json` file exists. If true, execute a Python script (`generate_rdjsonl.py`) to convert the issues JSON to a format that reviewdog accepts and creates another file (`suggestions.rdjsonl`). It uses [RDFormat with rdjsonl](https://github.com/reviewdog/reviewdog/tree/master/proto/rdf#rdjsonl).
+2. Verify if the `issues.json` file exists. If true, execute a Python script (`generate_rdjsonl.py`) to convert the issues JSON to a format that reviewdog accepts and creates another file (`suggestions.rdjsonl`). It uses [RDFormat with rdjsonl](https://github.com/reviewdog/reviewdog/tree/master/proto/rdf#rdjsonl). This script applies the following changes in the issues list before converting to RDFormat:
+    - Remove issues where the corrected text is equal to the original.
+    - If the original text is not found in the provided line number, try to find it in another line and update the line number. If it still isn't found, remove the issue.
+    - Aggregate issues in the same line into a single issue. When there are multiple issues in the same line, the explanation is posted as an unordered list.
 
 > [!NOTE]
 > The character/column count in RDFormat is different from the traditional byte count, since it uses UTF-8 encoding internally. This difference occurs with emojis and some special characters (e.g., `’`).

--- a/src/generate_rdjsonl.py
+++ b/src/generate_rdjsonl.py
@@ -22,7 +22,7 @@ def apply_corrections(original_line, original_pieces, corrections):
 def filter_unchanging_issues(issues):
     for issue in issues:
         if issue["text"] == issue["correction"]:
-            print(f"⚠️ [warn] Issue on line {issue['line']} has no change: '{issue['text']}'")
+            print(f"⚠️[warn] Issue on line {issue['line']} has no change: '{issue['text']}'")
             continue
         yield issue
 
@@ -35,14 +35,14 @@ def correct_line_issues(issues, original_lines, filename):
             yield issue
             continue
 
-        print(f"⚠️ [warn] Text '{issue['text']}' not found in line {issue['line']} of '{filename}'.")
+        print(f"⚠️[warn] Text '{issue['text']}' not found in line {issue['line']} of '{filename}'.")
 
         line_found = False
         for i_line in original_lines:
             if issue["text"] in i_line:
                 # If the text is found in another line, we can use that line instead
                 corrected_line = original_lines.index(i_line) + 1
-                print(f"ℹ️ [info] Using fallback for text '{issue['text']}'. Using line {corrected_line} instead of {issue['line']} in '{filename}'.")
+                print(f"ℹ️[info] Using fallback for text '{issue['text']}'. Using line {corrected_line} instead of {issue['line']} in '{filename}'.")
                 line_found = True
 
                 yield {
@@ -55,7 +55,7 @@ def correct_line_issues(issues, original_lines, filename):
                 break
 
         if not line_found:
-            print(f"⚠️ [warn] Text '{issue['text']}' not found in any line of '{filename}'. Skipping issue.")
+            print(f"⚠️[warn] Text '{issue['text']}' not found in any line of '{filename}'. Skipping issue.")
             continue
 
 def aggregate_issues(corrected_issues, original_lines, filename):

--- a/src/generate_rdjsonl.py
+++ b/src/generate_rdjsonl.py
@@ -35,14 +35,14 @@ def correct_line_issues(issues, original_lines, filename):
             yield issue
             continue
 
-        print(f"⚠️ [warn] Text '{issue["text"]}' not found in line {issue["line"]} of '{filename}'.")
+        print(f"⚠️ [warn] Text '{issue['text']}' not found in line {issue['line']} of '{filename}'.")
 
         line_found = False
         for i_line in original_lines:
             if issue["text"] in i_line:
                 # If the text is found in another line, we can use that line instead
                 corrected_line = original_lines.index(i_line) + 1
-                print(f"ℹ️ [info] Using fallback for text '{issue["text"]}'. Using line {corrected_line} instead of {issue["line"]} in '{filename}'.")
+                print(f"ℹ️ [info] Using fallback for text '{issue['text']}'. Using line {corrected_line} instead of {issue['line']} in '{filename}'.")
                 line_found = True
 
                 yield {
@@ -55,7 +55,7 @@ def correct_line_issues(issues, original_lines, filename):
                 break
 
         if not line_found:
-            print(f"⚠️ [warn] Text '{issue["text"]}' not found in any line of '{filename}'. Skipping issue.")
+            print(f"⚠️ [warn] Text '{issue['text']}' not found in any line of '{filename}'. Skipping issue.")
             continue
 
 def aggregate_issues(corrected_issues, original_lines, filename):

--- a/src/generate_rdjsonl.py
+++ b/src/generate_rdjsonl.py
@@ -19,6 +19,74 @@ def apply_corrections(original_line, original_pieces, corrections):
 
     return corrected_line
 
+def filter_unchanging_issues(issues):
+    for issue in issues:
+        if issue["text"] == issue["correction"]:
+            print(f"⚠️ [warn] Issue on line {issue['line']} has no change: '{issue['text']}'")
+            continue
+        yield issue
+
+def correct_line_issues(issues, original_lines, filename):
+    for issue in issues:
+        line_idx = issue["line"] - 1
+
+        if line_idx >= 0 and line_idx < len(original_lines) and issue["text"] in original_lines[line_idx]:
+            # If the text is found in the specified line, we can use it directly
+            yield issue
+            continue
+
+        print(f"⚠️ [warn] Text '{issue["text"]}' not found in line {issue["line"]} of '{filename}'.")
+
+        line_found = False
+        for i_line in original_lines:
+            if issue["text"] in i_line:
+                # If the text is found in another line, we can use that line instead
+                corrected_line = original_lines.index(i_line) + 1
+                print(f"ℹ️ [info] Using fallback for text '{issue["text"]}'. Using line {corrected_line} instead of {issue["line"]} in '{filename}'.")
+                line_found = True
+
+                yield {
+                    "line": corrected_line,
+                    "text": issue["text"],
+                    "correction": issue["correction"],
+                    "explanation": issue["explanation"]
+                }
+
+                break
+
+        if not line_found:
+            print(f"⚠️ [warn] Text '{issue["text"]}' not found in any line of '{filename}'. Skipping issue.")
+            continue
+
+def aggregate_issues(corrected_issues, original_lines, filename):
+    # Aggregate issues by line in a dict, where the key is the line number
+    issues_by_line = {}
+    for issue in corrected_issues:
+        line = issue["line"]
+        if line not in issues_by_line:
+            issues_by_line[line] = []
+        issues_by_line[line].append(issue)
+
+    for line, line_issues in issues_by_line.items():
+            if len(line_issues) == 1:
+                yield line_issues[0]
+            else:
+                if line < 1 or line > len(original_lines):
+                    print(f"⚠️[warn] Line {line} out of range for file '{filename}'. Skipping aggregation.")
+                    continue
+
+                explanations = "\n- " + "\n- ".join(i["explanation"] for i in line_issues)
+                original_pieces = [i["text"] for i in line_issues]
+                corrections = [i["correction"] for i in line_issues]
+
+                agg_issue = {
+                    "line": line,
+                    "text": original_lines[line-1],
+                    "correction": apply_corrections(original_lines[line-1], original_pieces, corrections),
+                    "explanation": explanations
+                }
+                yield agg_issue
+
 def make_rdjsonl_diagnostic(filename, issue, original_lines):
     # RDFormat expects 1-based line and column numbers
     line_idx = issue["line"] - 1
@@ -35,21 +103,8 @@ def make_rdjsonl_diagnostic(filename, issue, original_lines):
             # RDFormat counts columns using UTF-8 code points
             start_col = line.encode('utf-8').find(text.encode('utf-8')) + 1
         else:
-            print(f"⚠️[warn] Text '{text}' not found in line {issue['line']} of '{filename}'.")
+            return {}
 
-            start_col = 0
-            # If the text is not found in the provided line, try to find it in other lines
-            # This is a fallback mechanism to ensure we can still provide a diagnostic
-            for i in original_lines:
-                if text in i:
-                    start_col = i.encode('utf-8').find(text.encode('utf-8')) + 1
-                    correct_line = original_lines.index(i) + 1  # 1-based index
-                    print(f"ℹ️ [info] Using fallback for text '{text}'. Using line {correct_line} instead of {issue['line']} in '{filename}'.")
-                    break
-
-            if not start_col:
-                print(f"⚠️[warn] Text '{text}' not found in any line of '{filename}'.")
-                return {}
         end_col = start_col + len(text.encode('utf-8')) if start_col > 0 else 1
     return {
         "message": issue["explanation"],
@@ -83,37 +138,16 @@ def main():
         original_lines = Path(filename).read_text(encoding="utf-8").splitlines()
 
         # Filter out issues where the correction is the same as the original text
-        issues = [issue for issue in issues if issue["text"] != issue["correction"]]
+        filtered_issues = list(filter_unchanging_issues(issues))
 
-        # Aggregate issues by line in a dict, where the key is the line number
-        issues_by_line = {}
-        for issue in issues:
-            line = issue["line"]
-            if line not in issues_by_line:
-                issues_by_line[line] = []
-            issues_by_line[line].append(issue)
-        aggregated_issues = []
+        # If the text is not found in the provided line, try to find it in other lines
+        # This is a fallback mechanism to ensure we can still provide a diagnostic
+        corrected_issues = list(correct_line_issues(filtered_issues, original_lines, filename))
 
-        for line, line_issues in issues_by_line.items():
-            if len(line_issues) == 1:
-                aggregated_issues.append(line_issues[0])
-            else:
-                if line < 1 or line > len(original_lines):
-                    print(f"⚠️[warn] Line {line} out of range for file '{filename}'. Skipping aggregation.")
-                    continue
+        # Multiple issues on the same line will be aggregated into a single issue
+        aggregated_issues = list(aggregate_issues(corrected_issues, original_lines, filename))
 
-                explanations = "\n- " + "\n- ".join(i["explanation"] for i in line_issues)
-                original_pieces = [i["text"] for i in line_issues]
-                corrections = [i["correction"] for i in line_issues]
-
-                agg_issue = {
-                    "line": line,
-                    "text": original_lines[line-1],
-                    "correction": apply_corrections(original_lines[line-1], original_pieces, corrections),
-                    "explanation": explanations
-                }
-                aggregated_issues.append(agg_issue)
-
+        # Create RDFormat diagnostics for each aggregated issue
         for issue in aggregated_issues:
             diagnostic = make_rdjsonl_diagnostic(filename, issue, original_lines)
             if diagnostic:

--- a/src/generate_rdjsonl.py
+++ b/src/generate_rdjsonl.py
@@ -23,7 +23,7 @@ def make_rdjsonl_diagnostic(filename, issue, original_lines):
     # RDFormat expects 1-based line and column numbers
     line_idx = issue["line"] - 1
     if line_idx < 0 or line_idx >= len(original_lines):
-        # fallback to column 1 if out of range
+        # Fallback to column 1 if out of range
         start_col = 1
         end_col = 1
     else:
@@ -67,6 +67,10 @@ def main():
             print(f"⏩[skip] File '{filename}' not found.")
             continue
         original_lines = Path(filename).read_text(encoding="utf-8").splitlines()
+
+        # Filter out issues where the correction is the same as the original text
+        issues = [issue for issue in issues if issue["text"] != issue["correction"]]
+
         # Aggregate issues by line in a dict, where the key is the line number
         issues_by_line = {}
         for issue in issues:

--- a/src/grammar_reviewer.py
+++ b/src/grammar_reviewer.py
@@ -95,6 +95,8 @@ def post_pr_comment(body):
     pr.create_issue_comment(body)
 
 def main():
+    print("Starting grammar review with Gemini ...")
+
     files = get_changed_md_files()
     if not files:
         print("No Markdown files changed.")
@@ -125,6 +127,9 @@ def main():
     # Write all issues to a single issues.json file
     with open("issues.json", "w", encoding="utf-8") as f:
         json.dump(all_issues, f, indent=2)
+
+    print(" \nIssues found:")
+    print(f"{json.dumps(all_issues, indent=2, ensure_ascii=False)}\n ")
 
     print("✅ Grammar review completed. Issues saved to issues.json.")
 

--- a/src/grammar_reviewer.py
+++ b/src/grammar_reviewer.py
@@ -35,7 +35,7 @@ def review_grammar(file_path):
         lines = f.readlines()
 
     # Add line numbers to each line
-    numbered_content = ''.join(f"{i+1}: {line}" for i, line in enumerate(lines))
+    numbered_content = ''.join(f"{i+1}: ¬{line}¬" for i, line in enumerate(lines))
 
     response_schema = {
         "type": "object",
@@ -63,7 +63,7 @@ def review_grammar(file_path):
     prompt = (
         "Your task is to review the grammar, spelling, and typographic correctness of the provided Markdown content. "
         "Do not check for syntax of Markdown, HTML or any programming language. Ignore fenced code blocks. "
-        "Each line is prefixed with its line number, in the format `[line_number]: [content]`. For example: `1: This is the first line.` "
+        "Each line is prefixed with its line number, in the format `[line_number]: ¬[content]¬`. For example: `1: ¬This is the first line.¬` "
         "When reporting issues, use the provided line numbers. "
         "Return a JSON object with an 'issues' array (each with line, text, correction, explanation) and a 'summary' string.\n\n"
         f"{numbered_content}"


### PR DESCRIPTION
Changes in `grammar_reviewer.py`
- Add content delimiter (`¬`) to content in prompt and improve line identification
- Print JSON output

Changes in `generate_rdjsonl.py`:
- Filter out issues with unchanged corrections
- Add fallback to text not found in line
- Refactor script by encapsulating code in functions
- Improve warning prints