### PR TITLE
Add folders input (optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ To use this action in your GitHub repository, follow these steps:
                 github_token: ${{ secrets.GITHUB_TOKEN }}
     ```
 
+    The `folders` input is optional. When omitted, only changed files under `docs/` are reviewed. To restrict or extend which paths are reviewed, pass `folders` as a newline- or comma-separated list of folder prefixes (e.g. `docs`, `docs/guides`, `docs/release-notes`):
+
+    ```yml
+            - uses: vtexdocs/ai-grammar-reviewer-action@v0
+              with:
+                gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+                github_token: ${{ secrets.GITHUB_TOKEN }}
+                folders: |
+                  docs/guides
+                  docs/release-notes
+    ```
+
 ## Review tips
 
 Here are some tips to improve the review process with this action.

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
   github_token:
     description: 'GitHub Token'
     required: true
+  folders:
+    description: 'Folder prefixes to review (newline- or comma-separated). Only changed files under these paths are reviewed.'
+    required: false
+    default: 'docs'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -14,4 +18,5 @@ runs:
     GEMINI_API_KEY: ${{ inputs.gemini_api_key }}
     GITHUB_TOKEN: ${{ inputs.github_token }}
     REVIEWDOG_GITHUB_API_TOKEN: ${{ inputs.github_token }}
+    FOLDERS_TO_REVIEW: ${{ inputs.folders }}
   args: []

--- a/src/grammar_reviewer.py
+++ b/src/grammar_reviewer.py
@@ -17,9 +17,20 @@ if GITHUB_EVENT_PATH and os.path.exists(GITHUB_EVENT_PATH):
 pr_number = event.get('pull_request', {}).get('number')
 repo_name = event.get('repository', {}).get('full_name')
 
+def _parse_folders_to_review():
+    raw = os.environ.get('FOLDERS_TO_REVIEW', 'docs').strip()
+    folders = []
+    for line in raw.splitlines():
+        for part in line.split(','):
+            folder = part.strip()
+            if folder:
+                folders.append(folder)
+    return tuple(folders) if folders else ('docs',)
+
+
 # Find changed markdown files
 def get_changed_md_files():
-    valid_folders = ('docs/guides', 'docs/troubleshooting', 'docs/faststore', 'docs/release-notes')
+    valid_folders = _parse_folders_to_review()
 
     files = []
     if 'pull_request' in event:

--- a/src/grammar_reviewer.py
+++ b/src/grammar_reviewer.py
@@ -1,6 +1,5 @@
 import os
 import json
-import concurrent.futures
 import requests
 from github import Github
 from google import genai
@@ -85,28 +84,16 @@ def review_grammar(file_path):
     )
 
     client = genai.Client(api_key=GEMINI_API_KEY)
-    config = {
-        "response_mime_type": "application/json",
-        "temperature": 0.2,
-        "response_schema": response_schema,
-        "system_instruction": system_instruction
-    }
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-        future = executor.submit(
-            client.models.generate_content,
-            model="gemini-3-flash-preview",
-            contents=prompt,
-            config=config
-        )
-        try:
-            response = future.result(timeout=30)
-        except concurrent.futures.TimeoutError:
-            print("gemini-3-flash-preview timed out (>30s), retrying with gemini-2.5-flash ...")
-            response = client.models.generate_content(
-                model="gemini-2.5-flash",
-                contents=prompt,
-                config=config
-            )
+    response = client.models.generate_content(
+        model="gemini-2.5-flash",
+        contents=prompt,
+        config={
+            "response_mime_type": "application/json",
+            "temperature": 0.2,
+            "response_schema": response_schema,
+            "system_instruction": system_instruction
+        }
+    )
     try:
         return response.text
     except Exception:

--- a/src/grammar_reviewer.py
+++ b/src/grammar_reviewer.py
@@ -1,7 +1,7 @@
 import os
 import json
 import requests
-from github import Github
+from github import Auth, Github
 from google import genai
 from datetime import datetime, timezone
 
@@ -103,7 +103,7 @@ def post_pr_comment(body):
     if not (GITHUB_TOKEN and repo_name and pr_number):
         print("Missing GitHub context for commenting.")
         return
-    g = Github(GITHUB_TOKEN)
+    g = Github(auth=Auth.Token(GITHUB_TOKEN))
     repo = g.get_repo(repo_name)
     pr = repo.get_pull(pr_number)
 

--- a/src/grammar_reviewer.py
+++ b/src/grammar_reviewer.py
@@ -32,6 +32,7 @@ def _parse_folders_to_review():
 # Find changed markdown files
 def get_changed_md_files():
     valid_folders = _parse_folders_to_review()
+    print("Folders to review:", list(valid_folders))
 
     files = []
     if 'pull_request' in event:
@@ -98,9 +99,9 @@ def review_grammar(file_path):
             config=config
         )
         try:
-            response = future.result(timeout=90)
+            response = future.result(timeout=30)
         except concurrent.futures.TimeoutError:
-            print("gemini-3-flash-preview timed out (>90s), retrying with gemini-2.5-flash ...")
+            print("gemini-3-flash-preview timed out (>30s), retrying with gemini-2.5-flash ...")
             response = client.models.generate_content(
                 model="gemini-2.5-flash",
                 contents=prompt,
@@ -147,8 +148,6 @@ def post_pr_comment(body):
 
 def main():
     print("Starting grammar review with Gemini ...")
-    valid_folders = _parse_folders_to_review()
-    print("Folders to review:", list(valid_folders))
 
     files = get_changed_md_files()
     if not files:


### PR DESCRIPTION
Add optional input `folders` to workflows. With this input, workflows from other repos can choose the files from which folders will be reviewed. If `folders`is not defined in the workflow, the action uses the `docs/` folder as default.

Also, updated the authentication using the GitHub token internally.