### PR TITLE
Fix workflow inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,8 +33,8 @@ runs:
     GEMINI_API_KEY: ${{ inputs.gemini_api_key }}
     GITHUB_TOKEN: ${{ inputs.github_token }}
     REVIEWDOG_GITHUB_API_TOKEN: ${{ inputs.github_token }}
-    GITHUB_REPOSITORY: ${{ inputs.repository || github.repository }}
-    GITHUB_SHA: ${{ github.sha }}
+    GITHUB_REPOSITORY: ${{ inputs.repository }}
+    GITHUB_SHA: ${{ inputs.sha }}
     FOLDERS_TO_REVIEW: ${{ inputs.folders }}
     PR_NUMBER: ${{ inputs.pr_number }}
     PR_HEAD_REF: ${{ inputs.head_ref }}


### PR DESCRIPTION
Change environment variable inputs from `github.` to `inputs.`.